### PR TITLE
[MWPW-158444] Added stage domains map

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -123,6 +123,18 @@ const locales = {
   cis_en: { ietf: 'en', tk: 'pps7abe.css' },
 };
 
+const stageDomainsMap = {
+  'www.stage.adobe.com': {
+    'www.adobe.com': 'origin',
+  },
+  '--cc--adobecom.hlx.live': {
+    'www.adobe.com': 'origin',
+  },
+  '--cc--adobecom.hlx.page': {
+    'www.adobe.com': 'origin',
+  },
+};
+
 // Add any config options.
 const CONFIG = {
   contentRoot: '/cc-shared',
@@ -155,6 +167,7 @@ const CONFIG = {
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
   ],
+  stageDomainsMap,
 };
 
 /*


### PR DESCRIPTION
This PR adds the stageDomainsMap, enabling the conversion of production URLs to their stage equivalents in the stage environment.
More details about this feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

Resolves: [MWPW-158444](https://jira.corp.adobe.com/browse/MWPW-158444)

Test URLs:

Before: https://main--cc--adobecom.hlx.page?martech=off
After: https://mwpw-158444-domains-map--cc--adobecom.hlx.page?martech=off